### PR TITLE
Fix info button active state logic

### DIFF
--- a/assets/js/info-button.js
+++ b/assets/js/info-button.js
@@ -5,12 +5,21 @@ document.addEventListener('DOMContentLoaded', function () {
     if (infoButton && tooltip) {
         infoButton.addEventListener('click', function (event) {
             event.stopPropagation();
+            
+            // Toggle tooltip visibility
             tooltip.classList.toggle('visible');
-            infoButton.classList.toggle('active');
+            
+            // Set button active state based on tooltip visibility
+            if (tooltip.classList.contains('visible')) {
+                infoButton.classList.add('active');
+            } else {
+                infoButton.classList.remove('active');
+            }
         });
 
         document.addEventListener('click', function (event) {
             if (!tooltip.contains(event.target) && !infoButton.contains(event.target)) {
+                // Hide tooltip and deactivate button
                 tooltip.classList.remove('visible');
                 infoButton.classList.remove('active');
             }


### PR DESCRIPTION
Synchronize info button active state with info bubble visibility to fix incorrect coloration on dismissal.

The original logic used `classList.toggle()` for both the tooltip's visibility and the button's active state. This led to the button's state becoming out of sync with the tooltip's visibility when the button was clicked to dismiss the tooltip, particularly on mobile. The fix explicitly sets the button's active state based on whether the tooltip has the `visible` class, ensuring they are always synchronized.