### PR TITLE
Temporarily hide ReCODE acquisition references

### DIFF
--- a/blog/posts/index.json
+++ b/blog/posts/index.json
@@ -1,11 +1,5 @@
 [
   {
-    "title": "ReCODE Medical Has Been Acquired",
-    "date": "May 28, 2026",
-    "url": "./blog/recode-acquired",
-    "excerpt": "Today we announced that ReCODE Medical — the AI medical-coding company I co-founded — has been acquired."
-  },
-  {
     "title": "Weightless ONNX File Loader with ONNX2Torch",
     "date": "May 16, 2025",
     "url": "./blog/onnx2torch-weightless-loader",

--- a/blog/recode-acquired.html
+++ b/blog/recode-acquired.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ReCODE Medical Has Been Acquired | Luke R.</title>
+    <!-- STEALTH(recode-acquisition, 2026-02-23): original title -> <title>ReCODE Medical Has Been Acquired | Luke R.</title> -->
+    <title>Luke R.</title>
     <!-- Resolve theme before first paint (saved choice, else OS) - no flash -->
     <script src="../assets/js/theme-init.js"></script>
     <link rel="stylesheet" href="../assets/css/styles.css">
@@ -26,6 +27,7 @@
 <body>
     <div class="container">
         <div id="header-placeholder"></div>
+        <!-- STEALTH(recode-acquisition, 2026-02-23): post content temporarily hidden to avoid the appearance of a conflict of interest. This page is unlisted (removed from blog/posts/index.json) while hidden. To restore, delete this comment wrapper and re-add the index.json entry.
         <h1>ReCODE Medical Has Been Acquired</h1>
         <div class="post-meta">
             <span class="post-date">May 28, 2026</span>
@@ -42,6 +44,7 @@
 
             <p>Positioning oneself to benefit from the scaling enabled by AI is absolutely vital.</p>
         </article>
+        -->
 
         <footer class="footer">
             © 2026 Luke Rouleau. All rights reserved.

--- a/index.html
+++ b/index.html
@@ -117,7 +117,10 @@
                     <p class="entry-date"><time datetime="2024-09">2024</time><span class="entry-tag">Now</span></p>
                     <div class="entry-body">
                         <h3 class="entry-org"><a href="https://recodemedical.com" target="_blank" rel="noopener">ReCODE Medical</a></h3>
+                        <!-- STEALTH(recode-acquisition, 2026-02-23): acquisition reference temporarily hidden. To restore, swap the line below back to the original:
                         <p class="entry-role">Co-founded an AI medical-coding company, <a href="./blog/recode-acquired">recently acquired</a>.</p>
+                        -->
+                        <p class="entry-role">Co-founded an AI medical-coding company.</p>
                     </div>
                 </li>
             </ol>


### PR DESCRIPTION
Masks the post-Feb-2026 ReCODE Medical acquisition from the public site
to avoid the appearance of a conflict of interest. All changes are
reversible:

- index.html: strip "recently acquired" clause + link from the ReCODE
  ledger entry (original preserved in an HTML comment).
- blog/recode-acquired.html: wrap the post body in an HTML comment and
  neutralize the <title> so a direct URL reveals nothing.
- blog/posts/index.json: remove the listing entry so the post no longer
  appears on the musings page (content stays intact in the commented
  HTML + git history).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018oJVP3RvvX2PgwmiqHxeHu